### PR TITLE
Add terraform variables for agentpool nodeselector on dapr helm chart

### DIFF
--- a/infra/aks-spin-dapr/main.tf
+++ b/infra/aks-spin-dapr/main.tf
@@ -79,6 +79,7 @@ module "dapr" {
   cluster_name        = module.aks.CLUSTER_NAME
   dapr_namespace      = var.dapr_namespace
   dapr_version        = var.dapr_version
+  dapr_agentpool      = coalesce(var.dapr_agentpool, module.aks.DEFAULT_NODEPOOL_NAME)
   providers = {
     helm = helm
   }

--- a/infra/aks-spin-dapr/variables.tf
+++ b/infra/aks-spin-dapr/variables.tf
@@ -63,7 +63,7 @@ variable "user_nodepools" {
     labels = {
     }
     taints = []
-  }, {
+    }, {
     name       = "backend"
     size       = "Standard_B2ms"
     node_count = 3
@@ -110,4 +110,10 @@ variable "dapr_namespace" {
   type        = string
   default     = "dapr-system"
   description = "Kubernetes namespace to install Dapr in"
+}
+
+variable "dapr_agentpool" {
+  type        = string
+  default     = null
+  description = "Agent pool name to deploy Dapr to. Uses the default nodepool if null"
 }

--- a/infra/modules/az/aks/aks_output.tf
+++ b/infra/modules/az/aks/aks_output.tf
@@ -17,3 +17,7 @@ output "KUBE_ADMIN_CONFIG" {
 output "KUBE_ADMIN_CONFIG_RAW" {
   value = azurerm_kubernetes_cluster.aks.kube_admin_config_raw
 }
+
+output "DEFAULT_NODEPOOL_NAME" {
+  value = azurerm_kubernetes_cluster.aks.default_node_pool[0].name
+}

--- a/infra/modules/az/dapr/dapr.tf
+++ b/infra/modules/az/dapr/dapr.tf
@@ -6,18 +6,17 @@ resource "helm_release" "dapr" {
   create_namespace = true
   timeout          = 1200
 
-  set {
-    name  = "global.nodeSelector.agentpool"
-    value = "default"
-  }
-
-  set {
-    name  = "global.ha.enabled"
-    value = "true"
-  }
-
-  set {
-    name  = "global.tag"
-    value = "${var.dapr_version}-mariner"
-  }
+  values = [
+    <<-EOF
+    global:
+      nodeSelector:
+        agentpool: ${var.dapr_agentpool}
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+      ha:
+        enabled: true
+      tag: ${var.dapr_version}-mariner
+    EOF
+  ]
 }

--- a/infra/modules/az/dapr/dapr_variables.tf
+++ b/infra/modules/az/dapr/dapr_variables.tf
@@ -19,3 +19,9 @@ variable "dapr_namespace" {
   default     = "dapr-system"
   description = "Kubernetes namespace to install Dapr in"
 }
+
+variable "dapr_agentpool" {
+  type        = string
+  default     = "default"
+  description = "Agent pool name to deploy Dapr to"
+}


### PR DESCRIPTION
Hello! I ran into an issue deploying the terraform if I didn't name my default_node_pool "default" with the dapr helm chart so I thought I'd share my fix for the issue which was to add values to the dapr helm_release such that I could specify the agentpool's name or use the name from the provisioned resource.