### PR TITLE
Update scripts to support terraform remote state

### DIFF
--- a/helpers/orderdata-ts/run-aks-spin-dapr.sh
+++ b/helpers/orderdata-ts/run-aks-spin-dapr.sh
@@ -6,7 +6,7 @@ npx tsc
 
 REPO_ROOT=`git rev-parse --show-toplevel`
 TARGET_INFRA_FOLDER=$REPO_ROOT/infra/aks-spin-dapr
-RESOURCE_GROUP_NAME=`terraform output -state=$TARGET_INFRA_FOLDER/terraform.tfstate -json script_vars | jq -r .resource_group`
+RESOURCE_GROUP_NAME=`terraform -chdir=$TARGET_INFRA_FOLDER output -json script_vars | jq -r .resource_group`
 
 SERVICEBUS_NAMESPACE=`az resource list -g $RESOURCE_GROUP_NAME --resource-type Microsoft.ServiceBus/namespaces --query '[0].name' -o tsv`
 SERVICEBUS_CONNECTION=`az servicebus namespace authorization-rule keys list -g $RESOURCE_GROUP_NAME --namespace-name $SERVICEBUS_NAMESPACE -n RootManageSharedAccessKey --query primaryConnectionString -o tsv`
@@ -80,7 +80,7 @@ echo pr $PUSHRESPONSE
 SCHEDULE=`echo $PUSHRESPONSE | jq -r '.scheduledTimestamp'`
 echo s $SCHEDULE
 echo wait ${DELAY}m for scheduled time
-sleep ${DELAY}m
+sleep $(( $DELAY * 60 ))
 
 # ---- wait until all scheduled messages have been written to blob
 ACTUAL_COUNT=0

--- a/samples/spin-dapr-rs/build.sh
+++ b/samples/spin-dapr-rs/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 TARGET_INFRA_FOLDER=../../infra/aks-spin-dapr
-RESOURCE_GROUP_NAME=`terraform output -state=$TARGET_INFRA_FOLDER/terraform.tfstate -json script_vars | jq -r .resource_group`
+RESOURCE_GROUP_NAME=`terraform -chdir=$TARGET_INFRA_FOLDER output -json script_vars | jq -r .resource_group`
 AZURE_CONTAINER_REGISTRY_NAME=`az resource list -g $RESOURCE_GROUP_NAME --resource-type Microsoft.ContainerRegistry/registries --query '[0].name' -o tsv`
 AZURE_CONTAINER_REGISTRY_ENDPOINT=`az acr show -n $AZURE_CONTAINER_REGISTRY_NAME --query loginServer -o tsv`
 

--- a/samples/spin-dapr-rs/deploy.sh
+++ b/samples/spin-dapr-rs/deploy.sh
@@ -16,7 +16,7 @@ esac
 
 REPO_ROOT=`git rev-parse --show-toplevel`
 TARGET_INFRA_FOLDER=../../infra/aks-spin-dapr
-RESOURCE_GROUP_NAME=`terraform output -state=$TARGET_INFRA_FOLDER/terraform.tfstate -json script_vars | jq -r .resource_group`
+RESOURCE_GROUP_NAME=`terraform -chdir=$TARGET_INFRA_FOLDER output -json script_vars | jq -r .resource_group`
 
 APP=spin-dapr-rs
 SERVICEBUS_NAMESPACE=`az resource list -g $RESOURCE_GROUP_NAME --resource-type Microsoft.ServiceBus/namespaces --query '[0].name' -o tsv`

--- a/samples/spin-dapr-rs/run.sh
+++ b/samples/spin-dapr-rs/run.sh
@@ -7,7 +7,7 @@ set -e
 spin build
 
 TARGET_INFRA_FOLDER=../../infra/aks-spin-dapr
-RESOURCE_GROUP_NAME=`terraform output -state=$TARGET_INFRA_FOLDER/terraform.tfstate -json script_vars | jq -r .resource_group`
+RESOURCE_GROUP_NAME=`terraform -chdir=$TARGET_INFRA_FOLDER output -json script_vars | jq -r .resource_group`
 
 SERVICEBUS_NAMESPACE=`az resource list -g $RESOURCE_GROUP_NAME --resource-type Microsoft.ServiceBus/namespaces --query '[0].name' -o tsv`
 SERVICEBUS_CONNECTION=`az servicebus namespace authorization-rule keys list -g $RESOURCE_GROUP_NAME --namespace-name $SERVICEBUS_NAMESPACE -n RootManageSharedAccessKey --query primaryConnectionString -o tsv`

--- a/samples/spin-dapr-ts/build.sh
+++ b/samples/spin-dapr-ts/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 TARGET_INFRA_FOLDER=../../infra/aks-spin-dapr
-RESOURCE_GROUP_NAME=`terraform output -state=$TARGET_INFRA_FOLDER/terraform.tfstate -json script_vars | jq -r .resource_group`
+RESOURCE_GROUP_NAME=`terraform -chdir=$TARGET_INFRA_FOLDER output -json script_vars | jq -r .resource_group`
 AZURE_CONTAINER_REGISTRY_NAME=`az resource list -g $RESOURCE_GROUP_NAME --resource-type Microsoft.ContainerRegistry/registries --query '[0].name' -o tsv`
 AZURE_CONTAINER_REGISTRY_ENDPOINT=`az acr show -n $AZURE_CONTAINER_REGISTRY_NAME --query loginServer -o tsv`
 

--- a/samples/spin-dapr-ts/deploy.sh
+++ b/samples/spin-dapr-ts/deploy.sh
@@ -16,7 +16,7 @@ esac
 
 REPO_ROOT=`git rev-parse --show-toplevel`
 TARGET_INFRA_FOLDER=../../infra/aks-spin-dapr
-RESOURCE_GROUP_NAME=`terraform output -state=$TARGET_INFRA_FOLDER/terraform.tfstate -json script_vars | jq -r .resource_group`
+RESOURCE_GROUP_NAME=`terraform -chdir=$TARGET_INFRA_FOLDER output -json script_vars | jq -r .resource_group`
 
 APP=spin-dapr-ts
 SERVICEBUS_NAMESPACE=`az resource list -g $RESOURCE_GROUP_NAME --resource-type Microsoft.ServiceBus/namespaces --query '[0].name' -o tsv`


### PR DESCRIPTION
Hello! I updated the scripts to support using remote by switching the argument from `-state=$TARGET_INFRA_FOLDER/terraform.tfstate` to `-chdir=$TARGET_INFRA_FOLDER` in order to support pulling from remote state.

Additionally I updated the `orderdata-ts` app's script to pass an integer to `sleep` instead of `1m` which apparently isn't supported on macos.