### PR TITLE
Updates to for the spin-operator CRDs and bash scripts to run on macos

### DIFF
--- a/infra/aks-spin-dapr/main.tf
+++ b/infra/aks-spin-dapr/main.tf
@@ -29,6 +29,7 @@ module "aks" {
   location            = var.location
   resource_group_name = azurerm_resource_group.rg.name
   tags                = local.tags
+  cluster_version     = var.cluster_version
   resource_prefix     = local.base_name
   cluster_admins      = var.cluster_admins
   system_nodepool     = var.system_nodepool

--- a/infra/aks-spin-dapr/open-telemetry-collector-appinsights.yaml
+++ b/infra/aks-spin-dapr/open-telemetry-collector-appinsights.yaml
@@ -102,3 +102,5 @@ spec:
               - key: otel-collector-config
                 path: otel-collector-config.yaml
           name: otel-collector-config-vol
+      nodeSelector:
+        agentpool: default

--- a/infra/aks-spin-dapr/spin-executor-shim.yaml
+++ b/infra/aks-spin-dapr/spin-executor-shim.yaml
@@ -1,10 +1,7 @@
+apiVersion: core.spinoperator.dev/v1
 kind: SpinAppExecutor
 metadata:
   name: containerd-shim-spin
-  namespace: default
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "1"
 spec:
   createDeployment: true
   deploymentConfig:

--- a/samples/spin-dapr-rs/workload-aks-shared-spinapps.yml
+++ b/samples/spin-dapr-rs/workload-aks-shared-spinapps.yml
@@ -140,6 +140,7 @@ metadata:
   name: distributor
 spec:
   image: { will be replaced by deployment script }
+  executor: containerd-shim-spin
   enableAutoscaling: true
   deploymentAnnotations:
     scheduler.alpha.kubernetes.io/node-selector: agentpool=wasm
@@ -153,6 +154,7 @@ metadata:
   name: receiver-express
 spec:
   image: { will be replaced by deployment script }
+  executor: containerd-shim-spin
   enableAutoscaling: true
   deploymentAnnotations:
     scheduler.alpha.kubernetes.io/node-selector: agentpool=wasm
@@ -166,6 +168,7 @@ metadata:
   name: receiver-standard
 spec:
   image: { will be replaced by deployment script }
+  executor: containerd-shim-spin
   enableAutoscaling: true
   deploymentAnnotations:
     scheduler.alpha.kubernetes.io/node-selector: agentpool=wasm

--- a/samples/spin-dapr-ts/build.sh
+++ b/samples/spin-dapr-ts/build.sh
@@ -10,7 +10,7 @@ AZURE_CONTAINER_REGISTRY_PASSWORD=`az acr credential show -n $AZURE_CONTAINER_RE
 
 REVISION=`date +"%s"`
 
-if [ $1 == "docker"]; then
+if [ "$1" == "docker" ]; then
 
   az acr login -n $AZURE_CONTAINER_REGISTRY_NAME
 

--- a/samples/spin-dapr-ts/workload-aks-shared-spinapps.yml
+++ b/samples/spin-dapr-ts/workload-aks-shared-spinapps.yml
@@ -140,6 +140,7 @@ metadata:
   name: distributor
 spec:
   image: { will be replaced by deployment script }
+  executor: containerd-shim-spin
   enableAutoscaling: true
   deploymentAnnotations:
     scheduler.alpha.kubernetes.io/node-selector: agentpool=wasm
@@ -153,6 +154,7 @@ metadata:
   name: receiver-express
 spec:
   image: { will be replaced by deployment script }
+  executor: containerd-shim-spin
   enableAutoscaling: true
   deploymentAnnotations:
     scheduler.alpha.kubernetes.io/node-selector: agentpool=wasm
@@ -166,6 +168,7 @@ metadata:
   name: receiver-standard
 spec:
   image: { will be replaced by deployment script }
+  executor: containerd-shim-spin
   enableAutoscaling: true
   deploymentAnnotations:
     scheduler.alpha.kubernetes.io/node-selector: agentpool=wasm


### PR DESCRIPTION
Several fixes in here as I was going through the tests again that I found useful.

- Update scripts to work on macos
- Add delay parameters to orderdata-ts run script
- Fix kubectl scale to wait until it reaches target replicas
- Ensure otel-collector is running on the default node pool so it doesn't impact test runners
- Deploy spin-operator CRDs from remote URL using kustomize (no longer need to clone spin-operator)
- Update runtime date functions to use utc timestamps
- Pass `cluster_version` through terraform variables so setting it effects the resource
- Update prepare cluster script to include spin app executor
- Update spinapps templates for new CRDs
